### PR TITLE
Keep track of redirect hits and last access time

### DIFF
--- a/wp-redirects/admin-style.css
+++ b/wp-redirects/admin-style.css
@@ -1,0 +1,2 @@
+.column-hits { width: 75px; }
+.column-last_access { width: 150px; }


### PR DESCRIPTION
Resolves Issue #4.

Keeps track of redirect hits and last access time. Both columns are sortable and the hit counter can be reset.
## ![2014-09-11_00-59-46](https://cloud.githubusercontent.com/assets/53005/4229447/8975d910-3970-11e4-8d91-1f28c173ade5.png)

![2014-09-11_01-01-40](https://cloud.githubusercontent.com/assets/53005/4229452/c0b5b594-3970-11e4-80d4-13954a1049f6.png)

---

This should be thoroughly tested to ensure backwards compatibility with existing Redirects created with an earlier version of WP-Redirects. 
